### PR TITLE
Make WolframAlphaSkill use fallback system

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -25,7 +25,7 @@ from requests import HTTPError
 
 from mycroft.api import Api
 from mycroft.messagebus.message import Message
-from mycroft.skills.core import MycroftSkill
+from mycroft.skills.core import FallbackSkill
 from mycroft.util.log import getLogger
 from mycroft.util.parse import normalize
 
@@ -82,12 +82,12 @@ class WAApi(Api):
         return wolframalpha.Result(StringIO(data.content))
 
 
-class WolframAlphaSkill(MycroftSkill):
+class WolframAlphaSkill(FallbackSkill):
     PIDS = ['Value', 'NotableFacts:PeopleData', 'BasicInformation:PeopleData',
             'Definition', 'DecimalApproximation']
 
     def __init__(self):
-        MycroftSkill.__init__(self, name="WolframAlphaSkill")
+        FallbackSkill.__init__(self, name="WolframAlphaSkill")
         self.__init_client()
         self.question_parser = EnglishQuestionParser()
 


### PR DESCRIPTION
This changes the skill from registering with the directly with the message bus to registering with the skill intent fallback system. This relies on [this PR][core-pr] in the mycroft-core repo. To test view instructions on the Mycroft Core PR.

[core-pr]:https://github.com/MycroftAI/mycroft-core/issues/899